### PR TITLE
Adds repository entry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
   },
   "author": "Aaron Heckmann <aaron.heckmann+github@gmail.com>",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/pebble/event-loop-lag.git"
+  },
   "dependencies": {
     "debug": "1.0.4"
   },


### PR DESCRIPTION
...to silence this sort of thing when doing `npm install`:

```
npm WARN package.json event-loop-lag@1.0.2 No repository field.
```

and so npm will add a link to the [module page](https://www.npmjs.com/package/event-loop-lag).