### PR TITLE
Update module to use debug v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "git://github.com/pebble/event-loop-lag.git"
   },
   "dependencies": {
-    "debug": "^3.1.0"
+    "debug": "^4.1.1"
   },
   "devDependencies": {
     "mocha": "^5.2.0",


### PR DESCRIPTION
debug@3 is no longer mantained and has known vulnerabilities. debug@4 has the same support policy as this module, so no breaking changes are expected